### PR TITLE
Allow subclasses of UserObjects to be valid input even if they are defined after the object that references them

### DIFF
--- a/features/examples/modules/subclass_module.py
+++ b/features/examples/modules/subclass_module.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 from abc import ABC, abstractmethod
 
@@ -28,14 +28,14 @@ class Greyhound(Dog):
         return f"{self.name}, the greyhound, says Woof!"
 
 
+class Person(UserObject):
+    first_name: str = UserProperty(str)
+    last_name: str = UserProperty(str)
+    pets: List[Pet] = UserProperty(SchemaArray(Pet))
+
+
 class Cat(Pet):
     pet_type: str = UserProperty(SchemaConst("cat"))
 
     def speak(self):
         return f"{self.name} says Miaow!"
-
-
-class Person(UserObject):
-    first_name: str = UserProperty(str)
-    last_name: str = UserProperty(str)
-    pets: List[Pet] = UserProperty(SchemaArray(Pet))

--- a/wysdom/__version__.py
+++ b/wysdom/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 1)
+VERSION = (0, 2, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/wysdom/object_schema/SchemaAnyOf.py
+++ b/wysdom/object_schema/SchemaAnyOf.py
@@ -23,7 +23,8 @@ class SchemaAnyOf(Schema):
             allowed_schemas: Iterable[Schema],
             schema_ref_name: Optional[str] = None
     ) -> None:
-        self.allowed_schemas = tuple(allowed_schemas)
+        if allowed_schemas:
+            self.allowed_schemas = tuple(allowed_schemas)
         self.schema_ref_name = schema_ref_name
 
     def __call__(

--- a/wysdom/object_schema/SchemaAnyOf.py
+++ b/wysdom/object_schema/SchemaAnyOf.py
@@ -15,7 +15,7 @@ class SchemaAnyOf(Schema):
                             is referred to by other schemas.
     """
 
-    allowed_schemas: Tuple[Schema] = None
+    _allowed_schemas: Tuple[Schema] = None
     schema_ref_name: Optional[str] = None
 
     def __init__(
@@ -23,8 +23,7 @@ class SchemaAnyOf(Schema):
             allowed_schemas: Iterable[Schema],
             schema_ref_name: Optional[str] = None
     ) -> None:
-        if allowed_schemas:
-            self.allowed_schemas = tuple(allowed_schemas)
+        self._allowed_schemas = tuple(allowed_schemas)
         self.schema_ref_name = schema_ref_name
 
     def __call__(
@@ -47,6 +46,10 @@ class SchemaAnyOf(Schema):
                 f"No valid schema was found for the supplied value: {value}"
             )
         return valid_schemas[0](value, dom_info)
+
+    @property
+    def allowed_schemas(self) -> Tuple[Schema]:
+        return self._allowed_schemas
 
     @property
     def referenced_schemas(self) -> Dict[str, Schema]:

--- a/wysdom/user_objects/UserObject.py
+++ b/wysdom/user_objects/UserObject.py
@@ -75,20 +75,18 @@ class SchemaAnyRegisteredSubclass(SchemaAnyOf):
             allowed_schemas=[],
             schema_ref_name=f"{object_type.__module__}.{object_type.__name__}"
         )
+        assert issubclass(object_type, RegistersSubclasses)
         self.object_type = object_type
 
     @property
     def allowed_schemas(self) -> List[Schema]:
-        if issubclass(self.object_type, RegistersSubclasses):
-            return [
-                subclass.__json_schema__()
-                for subclass_list in self.object_type.registered_subclasses().values()
-                for subclass in subclass_list
-                if issubclass(subclass, UserObject)
-                and not isinstance(subclass.__json_schema__(), SchemaAnyOf)
-            ]
-        else:
-            return []
+        return [
+            subclass.__json_schema__()
+            for subclass_list in self.object_type.registered_subclasses().values()
+            for subclass in subclass_list
+            if issubclass(subclass, UserObject)
+            and not isinstance(subclass.__json_schema__(), SchemaAnyOf)
+        ]
 
 
 class UserObject(DOMObject):


### PR DESCRIPTION
Resolves #52 