### PR TITLE
Defer evaluation of a UserObject schema entirely to resolve #55

### DIFF
--- a/features/examples/modules/late_subclass_module.py
+++ b/features/examples/modules/late_subclass_module.py
@@ -1,0 +1,41 @@
+from typing import List
+
+from abc import ABC, abstractmethod
+
+from wysdom import UserObject, UserProperty, SchemaArray, SchemaConst
+from wysdom.mixins import RegistersSubclasses
+
+
+class Pet(UserObject, RegistersSubclasses, ABC):
+    pet_type: str = UserProperty(str)
+    name: str = UserProperty(str)
+
+    @abstractmethod
+    def speak(self):
+        pass
+
+
+class Person(UserObject):
+    first_name: str = UserProperty(str)
+    last_name: str = UserProperty(str)
+    pets: List[Pet] = UserProperty(SchemaArray(Pet))
+
+
+class Dog(Pet):
+
+    def speak(self):
+        return f"{self.name} says Woof!"
+
+
+class Greyhound(Dog):
+    pet_type: str = UserProperty(SchemaConst("greyhound"))
+
+    def speak(self):
+        return f"{self.name}, the greyhound, says Woof!"
+
+
+class Cat(Pet):
+    pet_type: str = UserProperty(SchemaConst("cat"))
+
+    def speak(self):
+        return f"{self.name} says Miaow!"

--- a/features/subclass.feature
+++ b/features/subclass.feature
@@ -1,8 +1,8 @@
 Feature: Test subclassed DOM objects
 
-  Scenario: Test good input string
+  Scenario Outline: Test good input string
 
-    Given the Python module subclass_module.py
+    Given the Python module <module>.py
     When we execute the following python code:
       """
       example_dict_input = {
@@ -19,12 +19,12 @@ Feature: Test subclassed DOM objects
           }
         ]
       }
-      example = subclass_module.Person(example_dict_input)
+      example = <module>.Person(example_dict_input)
       expected_schema = {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$ref": "#/definitions/subclass_module.Person",
+        "$ref": "#/definitions/<module>.Person",
         "definitions": {
-          "subclass_module.Greyhound": {
+          "<module>.Greyhound": {
             "type": "object",
             "properties": {
               "pet_type": {"const": "greyhound"},
@@ -33,7 +33,7 @@ Feature: Test subclassed DOM objects
             "required": ["name", "pet_type"],
             "additionalProperties": False
           },
-          "subclass_module.Cat": {
+          "<module>.Cat": {
             "type": "object",
             "properties": {
               "pet_type": {"const": "cat"},
@@ -42,20 +42,20 @@ Feature: Test subclassed DOM objects
             "required": ["name", "pet_type"],
             "additionalProperties": False
           },
-          "subclass_module.Pet": {
+          "<module>.Pet": {
             "anyOf": [
-              {"$ref": "#/definitions/subclass_module.Greyhound"},
-              {"$ref": "#/definitions/subclass_module.Cat"}
+              {"$ref": "#/definitions/<module>.Greyhound"},
+              {"$ref": "#/definitions/<module>.Cat"}
             ]
           },
-          "subclass_module.Person": {
+          "<module>.Person": {
             "type": "object",
             "properties": {
               "first_name": {"type": "string"},
               "last_name": {"type": "string"},
               "pets": {
                 "array": {
-                  "items": {"$ref": "#/definitions/subclass_module.Pet"}
+                  "items": {"$ref": "#/definitions/<module>.Pet"}
                 }
               }
             },
@@ -81,3 +81,9 @@ Feature: Test subclassed DOM objects
       copy.copy(example).to_builtin() == example_dict_input
       copy.deepcopy(example).to_builtin() == example_dict_input
       """
+
+    Examples:
+      | module               |
+      | subclass_module      |
+      | late_subclass_module |
+

--- a/wysdom/__version__.py
+++ b/wysdom/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 2)
+VERSION = (0, 2, 3)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/wysdom/mixins/RegistersSubclasses.py
+++ b/wysdom/mixins/RegistersSubclasses.py
@@ -125,3 +125,15 @@ class RegistersSubclasses(ABC):
 
 
 RegisteredSubclassList = List[Type[RegistersSubclasses]]
+
+
+def has_registered_subclasses(cls: type) -> bool:
+    """
+    Tests whether any class is a subclass of RegistersSubclasses and whether
+    it has any registered subclasses. If either is false, returns false.
+    """
+    has_subclasses = False
+    if issubclass(cls, RegistersSubclasses):
+        if cls.registered_subclasses():
+            has_subclasses = True
+    return has_subclasses

--- a/wysdom/mixins/__init__.py
+++ b/wysdom/mixins/__init__.py
@@ -1,3 +1,3 @@
 from .ReadsJSON import ReadsJSON
 from .ReadsYAML import ReadsYAML
-from .RegistersSubclasses import RegistersSubclasses
+from .RegistersSubclasses import RegistersSubclasses, has_registered_subclasses

--- a/wysdom/object_schema/SchemaAnyOf.py
+++ b/wysdom/object_schema/SchemaAnyOf.py
@@ -15,7 +15,7 @@ class SchemaAnyOf(Schema):
                             is referred to by other schemas.
     """
 
-    _allowed_schemas: Tuple[Schema] = None
+    allowed_schemas: Tuple[Schema] = None
     schema_ref_name: Optional[str] = None
 
     def __init__(
@@ -23,7 +23,7 @@ class SchemaAnyOf(Schema):
             allowed_schemas: Iterable[Schema],
             schema_ref_name: Optional[str] = None
     ) -> None:
-        self._allowed_schemas = tuple(allowed_schemas)
+        self.allowed_schemas = tuple(allowed_schemas)
         self.schema_ref_name = schema_ref_name
 
     def __call__(
@@ -46,10 +46,6 @@ class SchemaAnyOf(Schema):
                 f"No valid schema was found for the supplied value: {value}"
             )
         return valid_schemas[0](value, dom_info)
-
-    @property
-    def allowed_schemas(self) -> Tuple[Schema]:
-        return self._allowed_schemas
 
     @property
     def referenced_schemas(self) -> Dict[str, Schema]:


### PR DESCRIPTION
Closes #55 

Replaces class SchemaAnyRegisteredSubclass(SchemaAnyOf) with class UserObjectSchema(Schema), deferring the actual schema that a UserObject resolves to until it is used. This allows subclasses of the UserObject to be defined later, changing the resulting JSON schema (e.g. from a SchemaObject to a SchemaAnyOf, or adding additional options to a SchemaAnyOf).